### PR TITLE
modify Devices() to traverse underlying directories

### DIFF
--- a/device.go
+++ b/device.go
@@ -96,7 +96,7 @@ func Open(ctx context.Context) (*Device, error) {
 // open attempts to open a connection to a Stream Deck Device.
 func open(ctx context.Context) (*Device, error) {
 	// Get a list of all USB HID devices.
-	devices, err := hid.Devices()
+	devices, err := hid.Devices(hid.USBDevBus)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Hi, I was working on some related code and while I really liked the approach of avoiding cgo and doing things more idiomatic way I did notice that this library wasn't working out of the box.

Issue seems to have been in how the internal hid library traverses forward from the origin point (it tried to open the directory as a file). These changes fix the issue, at least for me.